### PR TITLE
Add mobile gallery landing

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,27 +1,43 @@
-// Basic gallery logic: handle uploads and show placeholder for Instagram.
-const uploadInput = document.getElementById('imageUpload');
-const gallery = document.getElementById('gallery');
-const emptyMessage = document.getElementById('emptyMessage');
+// Landing page logic for clickable gallery frames.
+const frames = document.querySelectorAll('.mockup');
+const dialog = document.getElementById('uploadDialog');
+const uploadBtn = document.getElementById('uploadBtn');
+const fileInput = document.getElementById('imageUpload');
 const connectBtn = document.getElementById('connectInstagram');
+const closeBtn = document.getElementById('closeDialog');
+let activeFrame = null;
 
-uploadInput.addEventListener('change', handleFiles);
-connectBtn.addEventListener('click', function () {
+frames.forEach(frame => {
+    frame.addEventListener('click', () => {
+        activeFrame = frame;
+        dialog.classList.remove('hidden');
+    });
+});
+
+closeBtn.addEventListener('click', closeDialog);
+dialog.addEventListener('click', e => {
+    if (e.target === dialog) closeDialog();
+});
+
+uploadBtn.addEventListener('click', () => fileInput.click());
+connectBtn.addEventListener('click', () => {
     alert('Instagram integration coming soon.');
 });
 
-function handleFiles(event) {
-    const files = event.target.files;
-    if (!files.length) return;
+fileInput.addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (!file || !activeFrame) return;
+    const reader = new FileReader();
+    reader.onload = ev => {
+        activeFrame.style.backgroundImage = `url(${ev.target.result})`;
+        activeFrame.classList.add('filled');
+    };
+    reader.readAsDataURL(file);
+    closeDialog();
+});
 
-    emptyMessage.style.display = 'none';
-
-    Array.from(files).forEach(file => {
-        const reader = new FileReader();
-        reader.onload = function (e) {
-            const img = document.createElement('img');
-            img.src = e.target.result;
-            gallery.appendChild(img);
-        };
-        reader.readAsDataURL(file);
-    });
+function closeDialog() {
+    dialog.classList.add('hidden');
+    fileInput.value = '';
+    activeFrame = null;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -5,23 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CNVS Gallery</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="app.js" defer></script>
 </head>
 <body>
     <header>
         <h1>CNVS Gallery</h1>
     </header>
-
     <main>
-        <section id="upload-section">
-            <input type="file" id="imageUpload" accept="image/*" multiple>
-            <button id="connectInstagram">Connect Instagram</button>
-        </section>
-
-        <section id="gallery" class="gallery">
-            <p id="emptyMessage">Your gallery is empty. Upload images or connect Instagram.</p>
+        <section id="mockups">
+            <div class="mockup" data-id="1"></div>
+            <div class="mockup" data-id="2"></div>
+            <div class="mockup" data-id="3"></div>
         </section>
     </main>
 
-    <script src="app.js"></script>
+    <div id="uploadDialog" class="dialog hidden">
+        <div class="dialog-content">
+            <button id="closeDialog" class="close" aria-label="Close dialog">&times;</button>
+            <p>Select an option to add art</p>
+            <input type="file" id="imageUpload" accept="image/*" hidden>
+            <button id="uploadBtn">Upload from device</button>
+            <button id="connectInstagram">Connect Instagram</button>
+        </div>
+    </div>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -9,29 +9,74 @@ header {
     padding: 1rem;
 }
 
-#upload-section {
+#mockups {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 1rem;
-}
-
-.gallery {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    flex-direction: column;
     gap: 1rem;
     padding: 1rem;
 }
 
-.gallery img {
+.mockup {
+    position: relative;
     width: 100%;
+    padding-top: 60%;
+    background: #e0e0e0;
+    border: 2px dashed #aaa;
+    cursor: pointer;
+    background-size: cover;
+    background-position: center;
+}
+.mockup::after {
+    content: "+";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 2rem;
+    color: #888;
+}
+
+.mockup.filled {
+    border-style: solid;
+}
+
+.dialog {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dialog.hidden {
+    display: none;
+}
+
+.dialog-content {
+    background: #fff;
+    padding: 1rem;
+    text-align: center;
+    width: 90%;
     max-width: 300px;
+    position: relative;
     border-radius: 4px;
 }
 
+.close {
+    position: absolute;
+    top: 0.25rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
 button {
+    display: block;
+    width: 100%;
+    margin: 0.5rem 0;
     padding: 0.5rem 1rem;
     font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- create a new landing page layout with three clickable gallery frames
- show an upload dialog with options for file upload or Instagram connection
- implement modal behaviour in JavaScript
- apply mobile-first styles and add a plus indicator on empty frames

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686805676ad48324aaa6fe37dcc65a87